### PR TITLE
Publish previewed gaze

### DIFF
--- a/_plugin.py
+++ b/_plugin.py
@@ -19,9 +19,7 @@ class PI_Preview(Plugin):
     order = 0.02  # ensures init after all plugins
 
     def __init__(
-        self,
-        g_pool,
-        linked_device=...,
+        self, g_pool, linked_device=...,
     ):
         super().__init__(g_pool)
 
@@ -30,10 +28,7 @@ class PI_Preview(Plugin):
         else:
             linked_device = Linked_Device(*linked_device)
 
-        self.connection = Connection(
-            linked_device,
-            update_ui_cb=self.update_ndsi_menu,
-        )
+        self.connection = Connection(linked_device, update_ui_cb=self.update_ndsi_menu,)
         self._num_prefix_elements = 0
 
     def recent_events(self, events):

--- a/connection.py
+++ b/connection.py
@@ -12,8 +12,7 @@ class Connection:
     def __init__(self, linked_device, update_ui_cb):
         self.update_ui_cb = update_ui_cb
         self.network = ndsi.Network(
-            formats={ndsi.DataFormat.V4},
-            callbacks=(self.on_event,)
+            formats={ndsi.DataFormat.V4}, callbacks=(self.on_event,)
         )
         self.network.start()
         self.sensor = GazeSensor(self.network, linked_device)

--- a/sensor.py
+++ b/sensor.py
@@ -115,4 +115,3 @@ class GazeSensor:
                     "host_name", self, label="Linked device", setter=lambda _: None
                 )
             )
-


### PR DESCRIPTION
Plugin runs after `pupil_data_relay` which is responsible for publishing gaze. Therefore, gaze received from PI was not published to the IPC. This PR adds a `Msg_Streamer` to the PI Preview plugin to fix this issue.

Simply running the preview plugin first does not work as `pupil_data_relay` would overwrite `events["gaze"]` and the PI gaze data would not be previewed or saved during a recording.